### PR TITLE
Allow to pass base_size parameter to parent class EffectRenderer from child classes

### DIFF
--- a/bubbles/renderers/image_effect_renderer.py
+++ b/bubbles/renderers/image_effect_renderer.py
@@ -5,8 +5,8 @@ from .effect_renderer import EffectRenderer
 
 class ImageEffectRenderer(EffectRenderer):
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self._shapes = {
             "circle": self._render_circle,
             "square": self._render_square

--- a/bubbles/renderers/pygame_effect_renderer.py
+++ b/bubbles/renderers/pygame_effect_renderer.py
@@ -4,8 +4,8 @@ from .effect_renderer import EffectRenderer
 
 
 class PygameEffectRenderer(EffectRenderer):
-    def __init__(self, per_pixel_alpha=False, colorkey=(0, 0, 0)):
-        super().__init__()
+    def __init__(self, per_pixel_alpha=False, colorkey=(0, 0, 0), **kwargs):
+        super().__init__(**kwargs)
         self._per_pixel_alpha = per_pixel_alpha
         self._colorkey = colorkey
         self._shapes = {


### PR DESCRIPTION
Currently, it is not possible to use the argument `base_size` when instanciating a renderer. This PR fixes that.